### PR TITLE
Xcode 16 type check fix

### DIFF
--- a/Sources/SwiftUICharts/Shared/Models/Protocols/SharedProtocols.swift
+++ b/Sources/SwiftUICharts/Shared/Models/Protocols/SharedProtocols.swift
@@ -146,6 +146,17 @@ public protocol CTSingleDataSetProtocol: CTDataSetProtocol {
     
 }
 
+extension CTSingleDataSetProtocol where Self.DataPoint: CTStandardDataPointProtocol {
+    
+    /// Get average for the DataSet
+    func average() -> Double {
+        dataPoints
+            .map(\.value)
+            .reduce(0, +)
+            .divide(by: Double(dataPoints.count))
+    }
+}
+
 /**
  Protocol for data sets that require a multiple sets of data .
  */

--- a/Sources/SwiftUICharts/Shared/Models/Protocols/SharedProtocols.swift
+++ b/Sources/SwiftUICharts/Shared/Models/Protocols/SharedProtocols.swift
@@ -146,17 +146,6 @@ public protocol CTSingleDataSetProtocol: CTDataSetProtocol {
     
 }
 
-extension CTSingleDataSetProtocol where Self.DataPoint: CTStandardDataPointProtocol {
-    
-    /// Get average for the DataSet
-    func average() -> Double {
-        dataPoints
-            .map(\.value)
-            .reduce(0, +)
-            .divide(by: Double(dataPoints.count))
-    }
-}
-
 /**
  Protocol for data sets that require a multiple sets of data .
  */

--- a/Sources/SwiftUICharts/Shared/Models/Protocols/SharedProtocolsExtensions.swift
+++ b/Sources/SwiftUICharts/Shared/Models/Protocols/SharedProtocolsExtensions.swift
@@ -222,10 +222,7 @@ extension CTMultiDataSetProtocol where Self.DataSet.DataPoint: CTStandardDataPoi
         
         self.dataSets
             .compactMap {
-                $0.dataPoints
-                    .map(\.value)
-                    .reduce(0, +)
-                    .divide(by: Double($0.dataPoints.count))
+                $0.average()
             }
             .reduce(0, +)
             .divide(by: Double(self.dataSets.count))

--- a/Sources/SwiftUICharts/Shared/Models/Protocols/SharedProtocolsExtensions.swift
+++ b/Sources/SwiftUICharts/Shared/Models/Protocols/SharedProtocolsExtensions.swift
@@ -221,8 +221,11 @@ extension CTMultiDataSetProtocol where Self.DataSet.DataPoint: CTStandardDataPoi
     public func average() -> Double {
         
         self.dataSets
-            .compactMap {
-                $0.average()
+            .compactMap { dataSet -> Double in
+                dataSet.dataPoints
+                    .map(\.value)
+                    .reduce(0, +)
+                    .divide(by: Double(dataSet.dataPoints.count))
             }
             .reduce(0, +)
             .divide(by: Double(self.dataSets.count))


### PR DESCRIPTION
* Declare the return type for the compactMap to resolve the type-check compiler error on Xcode 16. 